### PR TITLE
Edit output path to root instead of bin folder

### DIFF
--- a/TextSummarize/TextSummarize.csproj
+++ b/TextSummarize/TextSummarize.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>.\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Couldn't run due to an error on line 34 of WordPOSTagger.cs related to the ModelPath being set with AppDomain.CurrentDomain.BaseDirectory. AppDomain.CurrentDomain.BaseDirectory was returning the bin folder instead of the application root.